### PR TITLE
Remove unused variable in speex_resampler_init_frac()

### DIFF
--- a/src/resample.c
+++ b/src/resample.c
@@ -800,7 +800,6 @@ EXPORT SpeexResamplerState *speex_resampler_init(spx_uint32_t nb_channels, spx_u
 
 EXPORT SpeexResamplerState *speex_resampler_init_frac(spx_uint32_t nb_channels, spx_uint32_t ratio_num, spx_uint32_t ratio_den, spx_uint32_t in_rate, spx_uint32_t out_rate, int quality, int *err)
 {
-   spx_uint32_t i;
    SpeexResamplerState *st;
    int filter_err;
 


### PR DESCRIPTION
This fixes the following compiler warning:

    src/resample.c: In function 'libopusenc_resampler_init_frac':
    src/resample.c:803:17: warning: unused variable 'i' [-Wunused-variable]
        spx_uint32_t i;
                     ^
