### PR TITLE
Fix grouping for latest doxygen.

### DIFF
--- a/include/opusenc.h
+++ b/include/opusenc.h
@@ -72,14 +72,14 @@ extern "C" {
 #endif
 
 /**\defgroup error_codes Error Codes*/
-/*@{*/
+/**@{*/
 /**\name List of possible error codes
    Many of the functions in this library return a negative error code when a
     function fails.
    This list provides a brief explanation of the common errors.
    See each individual function for more details on what a specific error code
     means in that context.*/
-/*@{*/
+/**@{*/
 
 
 /* Bump this when we change the API. */
@@ -101,8 +101,8 @@ extern "C" {
 #define OPE_WRITE_FAIL -34
 #define OPE_CLOSE_FAIL -35
 
-/*@}*/
-/*@}*/
+/**@}*/
+/**@}*/
 
 
 /* These are the "raw" request values -- they should usually not be used. */
@@ -122,12 +122,12 @@ extern "C" {
 #define OPE_GET_NB_COUPLED_STREAMS_REQUEST  14015
 
 /**\defgroup encoder_ctl Encoding Options*/
-/*@{*/
+/**@{*/
 
 /**\name Control parameters
 
    Macros for setting encoder options.*/
-/*@{*/
+/**@{*/
 
 #define OPE_SET_DECISION_DELAY(x) OPE_SET_DECISION_DELAY_REQUEST, __opus_check_int(x)
 #define OPE_GET_DECISION_DELAY(x) OPE_GET_DECISION_DELAY_REQUEST, __opus_check_int_ptr(x)
@@ -144,16 +144,16 @@ extern "C" {
 #define OPE_GET_HEADER_GAIN(x) OPE_GET_HEADER_GAIN_REQUEST, __opus_check_int_ptr(x)
 #define OPE_GET_NB_STREAMS(x) OPE_GET_NB_STREAMS_REQUEST, __opus_check_int_ptr(x)
 #define OPE_GET_NB_COUPLED_STREAMS(x) OPE_GET_NB_COUPLED_STREAMS_REQUEST, __opus_check_int_ptr(x)
-/*@}*/
-/*@}*/
+/**@}*/
+/**@}*/
 
 /**\defgroup callbacks Callback Functions */
-/*@{*/
+/**@{*/
 
 /**\name Callback functions
 
    These are the callbacks that can be implemented for an encoder.*/
-/*@{*/
+/**@{*/
 
 /** Called for writing a page.
  \param user_data user-defined data passed to the callback
@@ -188,8 +188,8 @@ typedef struct {
   /** Callback for closing the stream. */
   ope_close_func close;
 } OpusEncCallbacks;
-/*@}*/
-/*@}*/
+/**@}*/
+/**@}*/
 
 /** Opaque comments struct. */
 typedef struct OggOpusComments OggOpusComments;
@@ -198,12 +198,12 @@ typedef struct OggOpusComments OggOpusComments;
 typedef struct OggOpusEnc OggOpusEnc;
 
 /**\defgroup comments Comments Handling */
-/*@{*/
+/**@{*/
 
 /**\name Functions for handling comments
 
    These functions make it possible to add comments and pictures to Ogg Opus files.*/
-/*@{*/
+/**@{*/
 
 /** Create a new comments object.
     \return Newly-created comments object. */
@@ -252,16 +252,16 @@ OPE_EXPORT int ope_comments_add_picture(OggOpusComments *comments, const char *f
  */
 OPE_EXPORT int ope_comments_add_picture_from_memory(OggOpusComments *comments, const char *ptr, size_t size, int picture_type, const char *description);
 
-/*@}*/
-/*@}*/
+/**@}*/
+/**@}*/
 
 /**\defgroup encoding Encoding */
-/*@{*/
+/**@{*/
 
 /**\name Functions for encoding Ogg Opus files
 
    These functions make it possible to encode Ogg Opus files.*/
-/*@{*/
+/**@{*/
 
 /** Create a new OggOpus file.
     \param path       Path where to create the file
@@ -394,8 +394,8 @@ OPE_EXPORT const char *ope_get_version_string(void);
     \return An integer representing the ABI version */
 OPE_EXPORT int ope_get_abi_version(void);
 
-/*@}*/
-/*@}*/
+/**@}*/
+/**@}*/
 
 # if defined(__cplusplus)
 }


### PR DESCRIPTION
Since doxygen 1.8.16, opening and closing a group must not be done as C comment but as doxygen command. In other words, not one but two asterisk characters are required so that doxygen finds a group. Found thanks to @Dario-Gasquez and its report about [opusfile](https://gitlab.xiph.org/xiph/opusfile/-/issues/2332).