### PR TITLE
Fix Runtime Issue

### DIFF
--- a/src/unicode_support.c
+++ b/src/unicode_support.c
@@ -34,6 +34,7 @@
 
 #include <windows.h>
 #include <io.h>
+#include <stdlib.h>
 
 static wchar_t *utf8_to_utf16(const char *input)
 {


### PR DESCRIPTION
When `WIN32_LEAN_AND_MEAN` is not defined on 64 bit version it crashes.
This is because malloc will return an int instead of a pointer.