### PR TITLE
fix misusing of `fread` in example

### DIFF
--- a/examples/opusenc_example.c
+++ b/examples/opusenc_example.c
@@ -29,7 +29,7 @@ int main(int argc, char **argv) {
   }
   while (1) {
     short buf[2*READ_SIZE];
-    int ret = fread(buf, 2*sizeof(short), READ_SIZE, fin);
+    int ret = fread(buf, sizeof(short), 2*READ_SIZE, fin);
     if (ret > 0) {
       ope_encoder_write(enc, buf, ret);
     } else break;


### PR DESCRIPTION
The use of `fread` function in example code is:

https://github.com/xiph/libopusenc/blob/e4285b5e8c20a06746f656102c5be8aef83f7ccb/examples/opusenc_example.c#L31-L32

But according to [`fread` documentation](https://www.ibm.com/docs/en/i/7.4?topic=functions-fread-read-items), although the 2nd and 3rd parameters will be multiplied together, the return value will be different(in case of full-read, the return value will be equal to 3rd parameter according to my test locally). So the variable `ret` will be different(prior is 256, current is 512, which equals to the length of buf).

Only this issue is fixed, the 3rd parameter of `ope_encoder_write` will write all data correctly. Otherwise it will write only half of the data, resulting in only half time length of the opus product in my local test(I'm using a 16000 sample rate, 1 channel pcm file for test. Already changed the `ope_encoder_create_file` parameters to `16000, 1, 0` for the local test).

Meanwhile, I'm not sure why we add a `2*` with READ_SIZE for the `buf`, we can remove both `2*` if it's useless.